### PR TITLE
update urls

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,8 @@
 
   Currently re-usable API to other pkgs are not explicitly provided.
   </description>
+  <maintainer email="ablasdel@gmail.com">Aaron Blasdel</maintainer>
+  <maintainer email="arne.hitzmann@gmail.com">Arne Hitzmann</maintainer>
   <maintainer email="namniart@gmail.com">Austin Hendrix</maintainer>
 
   <license>BSD</license>

--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,7 @@
    rqt_robot_monitor is a direct port to rqt of
    <a href = "http://www.ros.org/wiki/robot_monitor">robot_monitor</a>. All
    diagnostics are fall into one of three tree panes depending on the status of
-   diagnostics (normal, warning, error/stale). Status are shown in trees to 
+   diagnostics (normal, warning, error/stale). Status are shown in trees to
    represent their hierarchy. Worse status dominates the higher level status.<br />
    <ul>
     Ex. 'Computer' category has 3 sub devices. 2 are green but 1 is error. Then
@@ -20,9 +20,9 @@
 
   <license>BSD</license>
 
-  <url type="website">http://ros.org/wiki/rqt_robot_monitor</url>
-  <url type="repository">https://github.com/ros-visualization/rqt_robot_plugins/rqt_robot_monitor</url>
-  <url type="bugtracker">https://github.com/ros-visualization/rqt_robot_plugins/issues</url>
+  <url type="website">http://wiki.ros.org/rqt_robot_monitor</url>
+  <url type="repository">https://github.com/ros-visualization/rqt_robot_monitor</url>
+  <url type="bugtracker">https://github.com/ros-visualization/rqt_robot_monitor/issues</url>
 
   <author>Austin Hendrix</author>
   <author>Isaac Saito</author>
@@ -48,5 +48,3 @@
     <rqt_bag plugin="${prefix}/bag_plugin.xml" />
   </export>
 </package>
-
-


### PR DESCRIPTION
With the plugin being split out from `rqt_robot_plugins` I will do a last release for Lunar (as well as re-release for Kinetic, Jade, and Indigo) in the next days. After that I will stop watching this repo, not look at issues and pull requests, and not perform new releases.

Someone needs to take over the maintenance role which specifically includes doing new releases. @trainman419 You are currently listed in the manifest as the maintainer. I am not sure if you want to take this role and fully take over this repository? Or anyone else would like to step up (@ablasdel @arne48 @130s since you have contributed to the package in the past)?

Please let me know if you want to be added / removed from the list of maintainers in the manifest. Otherwise I will go ahead and merge this as-is and release the package a last time setting the maintenance status to `unmaintained`.