### PR TITLE
Fix apparent threading bug in timeline_view

### DIFF
--- a/src/rqt_robot_monitor/timeline.py
+++ b/src/rqt_robot_monitor/timeline.py
@@ -52,6 +52,7 @@ class Timeline(QObject):
     def __init__(self, topic, topic_type, count=30):
         super(Timeline, self).__init__()
         self._queue = deque(maxlen=count)
+        self._queue_copy = deque(maxlen=count)
         self._count = count
         self._current_index = -1 # rightmost item
 
@@ -86,6 +87,7 @@ class Timeline(QObject):
                 self._paused_queue = deque(self._queue, self._queue.maxlen)
             else:
                 self._queue = self._paused_queue
+                self._queue_copy = copy.deepcopy(self._paused_queue)
                 self._paused_queue = None
 
                 # update pointer to latest message
@@ -117,8 +119,13 @@ class Timeline(QObject):
             self._paused_queue.append(msg)
         else:
             self._queue.append(msg)
+            self._queue_copy = copy.deepcopy(self._queue)
+            self.queue_updated.emit(self._queue_copy)
             self.message_updated.emit(msg)
-            self.queue_updated.emit(copy.deepcopy(self._queue))
+
+    @property
+    def queue(self):
+        return self._queue_copy
 
     @property
     def has_messages(self):

--- a/src/rqt_robot_monitor/timeline.py
+++ b/src/rqt_robot_monitor/timeline.py
@@ -32,6 +32,7 @@
 #
 # Author: Austin Hendrix
 
+import copy
 from collections import deque
 from python_qt_binding.QtCore import Signal, Slot, QObject
 
@@ -45,6 +46,7 @@ class Timeline(QObject):
     It can be queried for a past history of diagnostics, and paused
     """
     message_updated = Signal(DiagnosticArray)
+    queue_updated = Signal(deque)
     pause_changed = Signal(bool)
 
     def __init__(self, topic, topic_type, count=30):
@@ -116,6 +118,7 @@ class Timeline(QObject):
         else:
             self._queue.append(msg)
             self.message_updated.emit(msg)
+            self.queue_updated.emit(copy.deepcopy(self._queue))
 
     @property
     def has_messages(self):
@@ -135,7 +138,7 @@ class Timeline(QObject):
     def is_stale(self):
         """ True is this timeline is stale. """
         return self.data_age() > 10.0
-        
+
     def set_position(self, index):
         max_index = len(self._queue) - 1
         min_index = -len(self._queue)

--- a/src/rqt_robot_monitor/timeline_view.py
+++ b/src/rqt_robot_monitor/timeline_view.py
@@ -84,6 +84,7 @@ class TimelineView(QGraphicsView):
         assert(self._timeline is None)
         self._name = name
         self._timeline = timeline
+        self._queue = self._timeline.queue
         self._timeline.queue_updated.connect(self._updated)
 
     @Slot(deque)
@@ -91,12 +92,6 @@ class TimelineView(QGraphicsView):
         """
         Update the widget whenever we receive a new message
         """
-        # update the limits
-        self._min = 0
-        self._max = len(self._timeline)-1
-
-        # update the marker position
-        self._xpos_marker = self._timeline.get_position()
 
         # update timeline queue
         self._queue = queue
@@ -188,6 +183,13 @@ class TimelineView(QGraphicsView):
         Gets called either when new msg comes in or when marker is moved by
         user.
         """
+        # update the limits
+        self._min = 0
+        self._max = len(self._timeline)-1
+
+        # update the marker position
+        self._xpos_marker = self._timeline.get_position()
+
         self._scene.clear()
 
         qsize = self.size()


### PR DESCRIPTION
I had a try on fixing the threading issue #1 described by @abencz .
This fix adds an additional signal to pass a deepcopy of the timeline queue to the timeline_view.
The copy of the queue is then stored locally in the timeline_view. 
So once the  _slot_redraw function is called its using a local copy to iterate over instead of the local variable of timeline which is prone to get updated by the message callback.
Fixing it this way seems like the least intrusive one since it is not altering any of the remaining update logic of the plugin.