### PR TITLE
Noetic release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rqt_robot_monitor)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+try:
+    from distutils.core import setup
+except ImportError:
+    from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
Following the guidelines to migrate packages to [noetic](http://wiki.ros.org/noetic/Migration)

- import setup from setuptools instead of distutils-core

- Bump CMake version to avoid CMP0048 warning
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.
