### PR TITLE
Temporary remove the rqt_bag dependency and plugin for a ROS 2 release

### DIFF
--- a/bag_plugin.xml
+++ b/bag_plugin.xml
@@ -1,7 +1,0 @@
-<library path="src">
-  <class name="RobotMonitorBagPlugin" type="rqt_robot_monitor.robot_monitor_bag_plugin.RobotMonitorBagPlugin" base_class_type="rqt_bag::Plugin">
-    <description>
-      An rqt_bag plugin for displaying diagnostics state
-    </description>
-  </class>
-</library>

--- a/package.xml
+++ b/package.xml
@@ -48,11 +48,9 @@
   <exec_depend>rqt_py_common</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
-  <exec_depend>rqt_bag</exec_depend>
 
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml" />
-    <rqt_bag plugin="${prefix}/bag_plugin.xml" />
     <build_type>ament_python</build_type>
   </export>
 </package>

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
         ('share/' + package_name, ['plugin.xml']),
-        ('share/' + package_name, ['bag_plugin.xml']),
         ('share/' + package_name + '/resource',
             ['resource/robotmonitor_mainwidget.ui']),
         ('share/' + package_name + '/resource',


### PR DESCRIPTION
Due to the current missing of the rqt_bag package in ROS 2 I propose to remove the export of the our plugin for rqt_bag in addition to the dependencies.
[https://github.com/ros-visualization/rqt_bag/pull/36](https://github.com/ros-visualization/rqt_bag/pull/36)
However, I would like to keep the codebase itself so once rqt_bag gets a ROS 2 release, we hopefully can add the plugin export again.