### PR TITLE
Fixing the timeline_view for the ros2 branch

### DIFF
--- a/src/rqt_robot_monitor/inspector_window.py
+++ b/src/rqt_robot_monitor/inspector_window.py
@@ -109,10 +109,10 @@ class InspectorWindow(QWidget):
 
     @Slot()
     def queue_updated(self):
-        '''
+        """
         This method just calls _signal_queue_updated in 'best effort' manner.
         This method should be called by signal with DirectConnection.
-        '''
+        """
         if self._queue_updated_processing:
             return
         self._queue_updated_processing = True
@@ -125,16 +125,15 @@ class InspectorWindow(QWidget):
         status = self.timeline.get_all_status_by_name(self._name)
         if status is not None:
             self.timeline_pane.set_levels([s.level for s in status])
-            self.timeline_pane.set_position(self.timeline.position)
             self.timeline_pane.redraw.emit()
             self._queue_updated_processing = False
 
     @Slot(dict)
     def message_updated(self, status):
-        '''
+        """
         This method just calls _signal_message_updated in 'best effort' manner.
         This method should be called by signal with DirectConnection.
-        '''
+        """
         if self._message_updated_processing:
             return
         self._message_updated_processing = True

--- a/src/rqt_robot_monitor/robot_monitor.py
+++ b/src/rqt_robot_monitor/robot_monitor.py
@@ -290,7 +290,7 @@ class RobotMonitorWidget(QWidget):
         """
         self._log_node.get_logger().debug('RobotMonitorWidget in shutdown')
 
-        names = self._inspectors.keys()
+        names = list(self._inspectors.keys())
         for name in names:
             self._inspectors[name].close()
 

--- a/src/rqt_robot_monitor/robot_monitor.py
+++ b/src/rqt_robot_monitor/robot_monitor.py
@@ -141,10 +141,10 @@ class RobotMonitorWidget(QWidget):
 
     @Slot(dict)
     def message_updated(self, status):
-        '''
+        """
         This method just calls _signal_message_updated in 'best effort' manner.
         This method should be called by signal with DirectConnection.
-        '''
+        """
         if self._message_updated_processing:
             return
         self._message_updated_processing = True
@@ -195,10 +195,10 @@ class RobotMonitorWidget(QWidget):
 
     @Slot()
     def queue_updated(self):
-        '''
+        """
         This method just calls _signal_queue_updated in 'best effort' manner.
         This method should be called by signal with DirectConnection.
-        '''
+        """
         if self._queue_updated_processing:
             return
         self._queue_updated_processing = True
@@ -311,6 +311,7 @@ class RobotMonitorWidget(QWidget):
         else:
             self.splitter.setSizes([100, 100, 200])
         # TODO(ahendrix): restore inspector windows
+
 
 def main(args=None):
     main_obj = Main()

--- a/src/rqt_robot_monitor/timeline.py
+++ b/src/rqt_robot_monitor/timeline.py
@@ -69,7 +69,7 @@ class Timeline(QObject):
         self._subscriber = self._node.create_subscription(topic_type,
                                                           topic,
                                                           self.callback,
-                                                          qos_profile= 10)
+                                                          qos_profile=10)
         
         self._node.get_logger().debug(
             "Timeline subscriber created with topic type {}, topic name {}".format(

--- a/src/rqt_robot_monitor/timeline_pane.py
+++ b/src/rqt_robot_monitor/timeline_pane.py
@@ -92,9 +92,9 @@ class TimelinePane(QWidget):
 
     @Slot(list)
     def set_levels(self, levels):
-        '''
+        """
         :param levels: List of status levels
-        '''
+        """
         self._timeline_view.set_levels(levels)
 
     @Slot(int)

--- a/src/rqt_robot_monitor/timeline_view.py
+++ b/src/rqt_robot_monitor/timeline_view.py
@@ -69,11 +69,11 @@ class TimelineView(QGraphicsView):
 
         self._min = 0
         self._max = 0
-        self._xpos_marker = 5
+        self._xpos_marker = -1
 
         self._timeline_marker_width = 15
         self._timeline_marker_height = 15
-        self._last_marker_at = 2
+        self._last_marker_at = -1
 
         self.setUpdatesEnabled(True)
         self._scene = QGraphicsScene(self)
@@ -117,7 +117,10 @@ class TimelineView(QGraphicsView):
         width = self.size().width()
         # determine value from mouse click
         width_cell = width / float(max(len(self._levels), 1))
-        return int(floor(x / width_cell))
+        position = int(floor(x / width_cell))
+        if position == len(self._levels) - 1:
+            return -1
+        return position
 
     @Slot(int)
     def set_marker_pos(self, xpos):
@@ -132,7 +135,8 @@ class TimelineView(QGraphicsView):
 
         if xpos == -1:
             # stick to the latest when position is -1
-            self._xpos_marker = xpos
+            self._xpos_marker = -1
+            #self.position_changed.emit(None)
             self.redraw.emit()
             return
 
@@ -184,7 +188,7 @@ class TimelineView(QGraphicsView):
 
         # update the limits
         self._min = 0
-        self._max = len(self._levels)-1
+        self._max = len(self._levels) - 1
 
         self._scene.clear()
 
@@ -211,13 +215,17 @@ class TimelineView(QGraphicsView):
 
             self._scene.addRect(w * i, 0, w, h, QColor('white'), qcolor)
 
-        # Setting marker.
+        # Getting marker index.
         xpos_marker = self._xpos_marker
-        while xpos_marker < 0:
-            xpos_marker += len(self._levels)
-        xpos_marker = (xpos_marker * w +
+
+        # If marker is -1 for latest use (number_of_cells -1)
+        if xpos_marker == -1:
+            xpos_marker = len(self._levels) - 1
+
+        # Convert get horizontal pixel value of selected cell's center
+        xpos_marker_in_pixel = (xpos_marker * w +
                        (w / 2.0) - (self._timeline_marker_width / 2.0))
-        pos_marker = QPointF(xpos_marker, 0)
+        pos_marker = QPointF(xpos_marker_in_pixel, 0)
 
         # Need to instantiate marker everytime since it gets deleted
         # in every loop by scene.clear()

--- a/src/rqt_robot_monitor/timeline_view.py
+++ b/src/rqt_robot_monitor/timeline_view.py
@@ -136,7 +136,12 @@ class TimelineView(QGraphicsView):
         if xpos == -1:
             # stick to the latest when position is -1
             self._xpos_marker = -1
-            #self.position_changed.emit(None)
+            # check if we chose latest item
+            if self._last_marker_at != self._xpos_marker:
+                # update variable to check for change during next round
+                self._last_marker_at = self._xpos_marker
+                # emit change to all timeline_panes
+                self.position_changed.emit(self._xpos_marker)
             self.redraw.emit()
             return
 


### PR DESCRIPTION
These patches fix the rendering of the currently selected message, as well as, the broadcasting of its state between the main window and potential inspector windows.
Before the "computer icon" for the current state would only appear after the 5th message was received.
Further was a change in the main window's timeline_view not forwarded to inspector windows and vice versa.

Now the icon is fixed from the first message on to the latest received message until another message's cell was clicked.
Once the right most cell is clicked, the view continues to select the most recent message.