### PR TITLE
Modifies the use of __slots__ for get_fields_and_field_types method

### DIFF
--- a/src/rqt_robot_monitor/robot_monitor_bag_plugin.py
+++ b/src/rqt_robot_monitor/robot_monitor_bag_plugin.py
@@ -67,7 +67,7 @@ class RobotMonitorBagView(TopicMessageView):
         msg = msg_details[1]
         # generic conversion of DiagnosticStatus from bag type to current type
         #  this should be fairly robust to minor changes in the message format
-        status = [DiagnosticStatus(**dict((slot, getattr(m, slot)) for slot in m.__slots__)) for m in msg.status]
+        status = [DiagnosticStatus(**dict((field_name, getattr(m, field_name)) for field_name in m.get_fields_and_field_types().keys())) for m in msg.status]
         msg = DiagnosticArray(msg.header, status)
         self._widget.message_updated.emit(msg)
 


### PR DESCRIPTION
## Summary
The attribute `__slots__` from a message represents all the attributes from the python class for that message, not only the field names of each component from the message structure. So far, this shouldn't impose any issue, however, taking into account the upcoming modifications from [this PR](https://github.com/ros2/rosidl_python/pull/194) in the `rosidl_python` package, the current use of the attribute in the `robot_monitor_bag_plugin.py` file would be affected and therefore, break something. 

This PR solves that issue by modifying the use of `__slots__` for the appropriate method to retrieve the field names and types `get_fields_and_field_types()`.