### PR TITLE
Fix for instantiation issue (#41)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/rqt_robot_monitor
+script_dir=$base/lib/rqt_robot_monitor
 [install]
-install-scripts=$base/lib/rqt_robot_monitor
+install_scripts=$base/lib/rqt_robot_monitor

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from setuptools import setup
 
 package_name = 'rqt_robot_monitor'

--- a/src/rqt_robot_monitor/robot_monitor.py
+++ b/src/rqt_robot_monitor/robot_monitor.py
@@ -82,7 +82,7 @@ class RobotMonitorWidget(QWidget):
                                'robotmonitor_mainwidget.ui')
         loadUi(ui_file, self)
 
-        self._log_node = rclpy.create_node('robot_monitor_log_node')
+        self._node = context.node
 
         obj_name = 'Robot Monitor'
         self.setObjectName(obj_name)
@@ -95,7 +95,7 @@ class RobotMonitorWidget(QWidget):
         #  this can be used later when writing an rqt_bag plugin
         if topic:
             # create timeline data structure
-            self._timeline = Timeline(topic, DiagnosticArray)
+            self._timeline = Timeline(topic, DiagnosticArray, node=self._node)
             self._timeline.message_updated.connect(
                 self.message_updated, Qt.DirectConnection)
             self._timeline.queue_updated.connect(
@@ -242,7 +242,7 @@ class RobotMonitorWidget(QWidget):
 
     def resizeEvent(self, evt):
         """Overridden from QWidget"""
-        self._log_node.get_logger().debug('RobotMonitorWidget resizeEvent')
+        self._node.get_logger().debug('RobotMonitorWidget resizeEvent')
         if self._timeline_pane:
             self._timeline_pane.redraw.emit()
 
@@ -263,7 +263,7 @@ class RobotMonitorWidget(QWidget):
         :type item: QTreeWidgetItem
         :type column: int
         """
-        self._log_node.get_logger().debug('RobotMonitorWidget _tree_clicked col={}'.format(column))
+        self._node.get_logger().debug('RobotMonitorWidget _tree_clicked col={}'.format(column))
 
         if item.name in self._inspectors:
             self._inspectors[item.name].activateWindow()
@@ -316,7 +316,7 @@ class RobotMonitorWidget(QWidget):
         This closes all the instances on all trees.
         Also unregisters ROS' subscriber, stops timer.
         """
-        self._log_node.get_logger().debug('RobotMonitorWidget in shutdown')
+        self._node.get_logger().debug('RobotMonitorWidget in shutdown')
 
         names = list(self._inspectors.keys())
         for name in names:

--- a/src/rqt_robot_monitor/timeline.py
+++ b/src/rqt_robot_monitor/timeline.py
@@ -51,7 +51,7 @@ class Timeline(QObject):
     pause_changed = Signal(bool)
     position_changed = Signal(int)
 
-    def __init__(self, topic, topic_type, count=30):
+    def __init__(self, topic, topic_type, node, count=30):
         super(Timeline, self).__init__()
         self._mutex = threading.RLock()
         self._queue = deque(maxlen=count)
@@ -65,7 +65,7 @@ class Timeline(QObject):
 
         self._last_message_time = 0
 
-        self._node = rclpy.create_node('timeline_subscriber')
+        self._node = node
         self._subscriber = self._node.create_subscription(topic_type,
                                                           topic,
                                                           self.callback,

--- a/src/rqt_robot_monitor/timeline_view.py
+++ b/src/rqt_robot_monitor/timeline_view.py
@@ -65,8 +65,6 @@ class TimelineView(QGraphicsView):
         super(TimelineView, self).__init__(parent=parent)
         self._timeline_marker = QIcon.fromTheme('system-search')
 
-        self._log_node = rclpy.create_node('timeline_log_node')
-
         self._min = 0
         self._max = 0
         self._xpos_marker = -1
@@ -130,7 +128,6 @@ class TimelineView(QGraphicsView):
         :param xpos: Marker index
         """
         if self._levels is None:
-            self._log_node.get_logger().warn("Called set_marker_pos before set_levels")
             return
 
         if xpos == -1:


### PR DESCRIPTION
The issue was that this plugin instantiated several nodes.
When starting the plugin via a launch file the given name overrides the hardcoded node names with the same value for all.
This causes warnings and shouldn't be considered good practice.
This fix gets the plugin node via its context and hand it over to the individual parts which need pub/sub functionality.
