### PR TITLE
Fixed diagnostics display in rqt_bag

### DIFF
--- a/src/rqt_robot_monitor/inspector_window.py
+++ b/src/rqt_robot_monitor/inspector_window.py
@@ -68,22 +68,25 @@ class InspectorWindow(QWidget):
         self._message_updated_processing = False
         self._queue_updated_processing = False
 
-        self.timeline = timeline
-        self.timeline.message_updated.connect(
-            self.message_updated, Qt.DirectConnection)
-        self.timeline.queue_updated.connect(
-            self.queue_updated, Qt.DirectConnection)
         self._message_updated.connect(
             self._signal_message_updated, Qt.QueuedConnection)
         self._queue_updated.connect(
             self._signal_queue_updated, Qt.QueuedConnection)
 
-        self.timeline_pane = TimelinePane(self, self.timeline.paused)
-        self.timeline_pane.pause_changed.connect(self.timeline.set_paused)
-        self.timeline_pane.position_changed.connect(self.timeline.set_position)
-        self.timeline.pause_changed.connect(self.timeline_pane.set_paused)
-        self.timeline.position_changed.connect(self.timeline_pane.set_position)
-        self.layout_vertical.addWidget(self.timeline_pane, 0)
+        self.timeline = timeline
+
+        if self.timeline is not None:
+            self.timeline.message_updated.connect(
+                self.message_updated, Qt.DirectConnection)
+            self.timeline.queue_updated.connect(
+                self.queue_updated, Qt.DirectConnection)
+
+            self.timeline_pane = TimelinePane(self, self.timeline.paused)
+            self.timeline_pane.pause_changed.connect(self.timeline.set_paused)
+            self.timeline_pane.position_changed.connect(self.timeline.set_position)
+            self.timeline.pause_changed.connect(self.timeline_pane.set_paused)
+            self.timeline.position_changed.connect(self.timeline_pane.set_position)
+            self.layout_vertical.addWidget(self.timeline_pane, 0)
 
         self.snapshot = QPushButton("Snapshot")
         self.snapshot.clicked.connect(self._take_snapshot)

--- a/src/rqt_robot_monitor/robot_monitor.py
+++ b/src/rqt_robot_monitor/robot_monitor.py
@@ -84,6 +84,10 @@ class RobotMonitorWidget(QWidget):
 
         self._message_updated_processing = False
         self._queue_updated_processing = False
+        self._displayed_status = None
+
+        self._message_updated.connect(
+            self._signal_message_updated, Qt.QueuedConnection)
 
         # if we're given a topic, create a timeline. otherwise, don't
         #  this can be used later when writing an rqt_bag plugin
@@ -94,8 +98,6 @@ class RobotMonitorWidget(QWidget):
                 self.message_updated, Qt.DirectConnection)
             self._timeline.queue_updated.connect(
                 self.queue_updated, Qt.DirectConnection)
-            self._message_updated.connect(
-                self._signal_message_updated, Qt.QueuedConnection)
             self._queue_updated.connect(
                 self._signal_queue_updated, Qt.QueuedConnection)
 
@@ -147,6 +149,14 @@ class RobotMonitorWidget(QWidget):
     @Slot(dict)
     def _signal_message_updated(self, status):
         """ DiagnosticArray message callback """
+
+        self._displayed_status = status
+
+        # If timeline is not set, we need to notify the open inspectors
+        if self._timeline is None:
+            for name, s in status.items():
+                if name in self._inspectors:
+                    self._inspectors[name].message_updated(status)
 
         if self.alternative_view_checkBox.isChecked():
             # Walk the status array and update the tree
@@ -266,6 +276,8 @@ class RobotMonitorWidget(QWidget):
             insp.show()
             insp.closed.connect(self._inspector_closed)
             self._inspectors[item.name] = insp
+            if self._timeline is None:
+                insp.message_updated(self._displayed_status)
 
     def _update_message_state(self):
         """ Update the display if it's stale """

--- a/src/rqt_robot_monitor/robot_monitor_bag_plugin.py
+++ b/src/rqt_robot_monitor/robot_monitor_bag_plugin.py
@@ -68,8 +68,7 @@ class RobotMonitorBagView(TopicMessageView):
         # generic conversion of DiagnosticStatus from bag type to current type
         #  this should be fairly robust to minor changes in the message format
         status = [DiagnosticStatus(**dict((slot, getattr(m, slot)) for slot in m.__slots__)) for m in msg.status]
-        msg = DiagnosticArray(msg.header, status)
-        self._widget.message_updated.emit(msg)
+        self._widget.message_updated({s.name: s for s in status})
 
     def close(self):
         self._widget.shutdown()  # Closes unclosed popup windows.


### PR DESCRIPTION
PR #11 broke diagnostics display in rqt_bag. This PR brings the functionality back.

I don't know if inspector windows worked in rqt_bag, but with this PR, they do.