### PR TITLE
Initial support for bag_plugin in ROS 2

### DIFF
--- a/bag_plugin.xml
+++ b/bag_plugin.xml
@@ -1,0 +1,7 @@
+<library path="src">
+  <class name="RobotMonitorBagPlugin" type="rqt_robot_monitor.robot_monitor_bag_plugin.RobotMonitorBagPlugin" base_class_type="rqt_bag::Plugin">
+    <description>
+      An rqt_bag plugin for displaying diagnostics state
+    </description>
+  </class>
+</library>

--- a/package.xml
+++ b/package.xml
@@ -45,11 +45,13 @@
   <exec_depend>qt_gui</exec_depend>
   <exec_depend>qt_gui_py_common</exec_depend>
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>rqt_bag</exec_depend>
   <exec_depend>rqt_py_common</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
 
   <export>
+    <rqt_bag plugin="${prefix}/bag_plugin.xml" />
     <rqt_gui plugin="${prefix}/plugin.xml" />
     <build_type>ament_python</build_type>
   </export>

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
+        ('share/' + package_name, ['bag_plugin.xml']),
         ('share/' + package_name, ['plugin.xml']),
         ('share/' + package_name + '/resource',
             ['resource/robotmonitor_mainwidget.ui']),

--- a/src/rqt_robot_monitor/robot_monitor_bag_plugin.py
+++ b/src/rqt_robot_monitor/robot_monitor_bag_plugin.py
@@ -52,7 +52,7 @@ class RobotMonitorBagPlugin(Plugin):
         return None
 
     def get_message_types(self):
-        return ['diagnostic_msgs/DiagnosticArray']
+        return ['diagnostic_msgs/msg/DiagnosticArray']
 
 class RobotMonitorBagView(TopicMessageView):
     name = 'Diagnostics Viewer'


### PR DESCRIPTION
ROS 2 does not include the rqt_bag plugin provided from rqt_robot_monitor. This PR is a kickstart for such support.

It does not work yet. The plugin gets loaded by rqt_bag, but I end on this exception:

```
Traceback (most recent call last):
  File "ws/build/rqt_bag/src/rqt_bag/timeline_frame.py", line 1339, in mousePressEvent                                                                                                                 
    TimelinePopupMenu(self._bag_timeline, event, topic)                                                                                                                                                                    
  File "ws/build/rqt_bag/src/rqt_bag/timeline_menu.py", line 218, in __init__                                                                                                                          
    self.process(action)                                                                                                                                                                                                   
  File "ws/build/rqt_bag/src/rqt_bag/timeline_menu.py", line 268, in process                                                                                                                           
    frame.show(self.timeline.get_context())                                                                                                                                                                                
  File "ws/build/rqt_bag/src/rqt_bag/timeline_menu.py", line 84, in show                                                                                                                               
    self._viewer = self._viewer_type(self._timeline, self, self._topic)                                                                                                                                                    
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                    
  File "ws/build/rqt_robot_monitor/src/rqt_robot_monitor/robot_monitor_bag_plugin.py", line 63, in __init__                                                                                            
    self._widget = RobotMonitorWidget(parent)                                                                                                                                                                              
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                              
  File "ws/build/rqt_robot_monitor/src/rqt_robot_monitor/robot_monitor.py", line 85, in __init__                                                                                                       
    self._node = context.node                                                                                                                                                                                              
                 ^^^^^^^^^^^^                                                                                                                                                                                              
AttributeError: 'TopicPopupWidget' object has no attribute 'node'
```